### PR TITLE
Enable offline Local 360 playback with VR split-screen, gyro head-tracking and pinch/zoom

### DIFF
--- a/app/src/main/java/com/arashivision/sdk/demo/ui/player/LocalSphericalPlayerActivity.kt
+++ b/app/src/main/java/com/arashivision/sdk/demo/ui/player/LocalSphericalPlayerActivity.kt
@@ -2,26 +2,42 @@ package com.arashivision.sdk.demo.ui.player
 
 import android.content.Intent
 import android.net.Uri
+import android.view.ScaleGestureDetector
+import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import com.arashivision.sdk.demo.R
 import com.arashivision.sdk.demo.base.BaseActivity
 import com.arashivision.sdk.demo.base.BaseEvent
 import com.arashivision.sdk.demo.databinding.ActivityLocalSphericalPlayerBinding
-import com.arashivision.sdk.demo.ui.capture.GyroOrientationController
 
 /**
- * Локальный режим: берет equirectangular-видео с телефона и рендерит его на сферу,
- * чтобы управлять обзором гироскопом.
+ * Локальный режим: берет equirectangular-видео с телефона и рендерит его на сферу.
+ * Поддержка:
+ * - офлайн-воспроизведение без подключения к камере;
+ * - head-tracking через useSensorRotation;
+ * - VR split-screen без лишних оверлеев;
+ * - loop playback;
+ * - zoom (кнопки + pinch).
  */
 class LocalSphericalPlayerActivity :
     BaseActivity<ActivityLocalSphericalPlayerBinding, LocalSphericalPlayerViewModel>() {
 
-    private var player: ExoPlayer? = null
-    private lateinit var gyroController: GyroOrientationController
-    private var sensorRotationEnabled: Boolean = true
+    private var mainPlayer: ExoPlayer? = null
+    private var vrPlayer: ExoPlayer? = null
+
+    private var sensorRotationEnabled = true
+    private var isVrMode = false
+    private var currentVideoUri: Uri? = null
+
+    private var zoomFactor = 1.0f
+    private val minZoom = 1.0f
+    private val maxZoom = 2.5f
+
+    private lateinit var scaleGestureDetector: ScaleGestureDetector
 
     private val pickVideoLauncher =
         registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
@@ -30,42 +46,61 @@ class LocalSphericalPlayerActivity :
                 contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
             binding.tvSelectedVideo.text = uri.toString()
+            currentVideoUri = uri
             startPlayback(uri)
         }
 
     override fun initView() {
         super.initView()
-        binding.sphericalView.setDefaultStereoMode(C.STEREO_MODE_MONO)
-        sensorRotationEnabled = true
-        binding.sphericalView.setUseSensorRotation(sensorRotationEnabled)
-
-        gyroController = GyroOrientationController(
-            context = this,
-            getDisplayRotation = { windowManager.defaultDisplay.rotation },
-            applyOrientation = { _, _ -> }
-        )
+        setupSphericalViews()
+        scaleGestureDetector = ScaleGestureDetector(this, ZoomGestureListener())
+        binding.sphericalContainer.setOnTouchListener { _, event ->
+            scaleGestureDetector.onTouchEvent(event)
+            isVrMode
+        }
+        updateZoom()
+        updateVrUi()
     }
 
     override fun initListener() {
         super.initListener()
         binding.btnPickVideo.setOnClickListener { pickVideoLauncher.launch(arrayOf("video/*")) }
 
+        binding.btnPlayPause.setOnClickListener {
+            val newPlayState = !(mainPlayer?.isPlaying ?: false)
+            setPlayWhenReady(newPlayState)
+            syncPlayPauseButton()
+        }
+
         binding.btnToggleSensor.setOnClickListener {
             sensorRotationEnabled = !sensorRotationEnabled
             binding.sphericalView.setUseSensorRotation(sensorRotationEnabled)
-            binding.btnToggleSensor.text = if (sensorRotationEnabled) getString(R.string.disable_gyro_control) else getString(R.string.enable_gyro_control)
+            binding.sphericalViewSecondary.setUseSensorRotation(sensorRotationEnabled)
+            binding.btnToggleSensor.text = if (sensorRotationEnabled) {
+                getString(R.string.disable_gyro_control)
+            } else {
+                getString(R.string.enable_gyro_control)
+            }
         }
 
         binding.btnCenterView.setOnClickListener {
-            gyroController.calibrate()
+            recenterSensorView()
             toast(R.string.gyro_recentered)
         }
 
-        binding.btnPlayPause.setOnClickListener {
-            player?.let {
-                it.playWhenReady = !it.playWhenReady
-                syncPlayPauseButton()
-            }
+        binding.btnToggleVr.setOnClickListener {
+            isVrMode = !isVrMode
+            updateVrUi()
+        }
+
+        binding.btnZoomIn.setOnClickListener {
+            zoomFactor = (zoomFactor + 0.1f).coerceIn(minZoom, maxZoom)
+            updateZoom()
+        }
+
+        binding.btnZoomOut.setOnClickListener {
+            zoomFactor = (zoomFactor - 0.1f).coerceIn(minZoom, maxZoom)
+            updateZoom()
         }
     }
 
@@ -73,42 +108,114 @@ class LocalSphericalPlayerActivity :
 
     override fun onStart() {
         super.onStart()
-        if (player == null) {
-            player = ExoPlayer.Builder(this).build().also { exo ->
-                exo.setVideoSurfaceView(binding.sphericalView)
-            }
-        }
+        ensurePlayers()
     }
 
     override fun onResume() {
         super.onResume()
-        gyroController.start()
-        player?.playWhenReady = true
+        setPlayWhenReady(true)
         syncPlayPauseButton()
     }
 
     override fun onPause() {
-        gyroController.stop()
-        player?.playWhenReady = false
+        setPlayWhenReady(false)
         super.onPause()
     }
 
     override fun onStop() {
-        player?.release()
-        player = null
+        releasePlayers()
         super.onStop()
     }
 
+    private fun setupSphericalViews() {
+        binding.sphericalView.setDefaultStereoMode(C.STEREO_MODE_MONO)
+        binding.sphericalViewSecondary.setDefaultStereoMode(C.STEREO_MODE_MONO)
+        binding.sphericalView.setUseSensorRotation(sensorRotationEnabled)
+        binding.sphericalViewSecondary.setUseSensorRotation(sensorRotationEnabled)
+    }
+
+    private fun ensurePlayers() {
+        if (mainPlayer == null) {
+            mainPlayer = ExoPlayer.Builder(this).build().also { exo ->
+                exo.repeatMode = Player.REPEAT_MODE_ALL
+                exo.setVideoSurfaceView(binding.sphericalView)
+            }
+        }
+
+        if (vrPlayer == null) {
+            vrPlayer = ExoPlayer.Builder(this).build().also { exo ->
+                exo.repeatMode = Player.REPEAT_MODE_ALL
+                exo.volume = 0f
+                exo.setVideoSurfaceView(binding.sphericalViewSecondary)
+            }
+        }
+
+        currentVideoUri?.let { startPlayback(it) }
+    }
+
+    private fun releasePlayers() {
+        mainPlayer?.release()
+        vrPlayer?.release()
+        mainPlayer = null
+        vrPlayer = null
+    }
+
     private fun startPlayback(uri: Uri) {
-        val exo = player ?: return
-        exo.setMediaItem(MediaItem.fromUri(uri))
-        exo.prepare()
-        exo.playWhenReady = true
+        val main = mainPlayer ?: return
+        val vr = vrPlayer ?: return
+
+        val mediaItem = MediaItem.fromUri(uri)
+        main.setMediaItem(mediaItem)
+        vr.setMediaItem(mediaItem)
+        main.prepare()
+        vr.prepare()
+
+        setPlayWhenReady(true)
         syncPlayPauseButton()
     }
 
+    private fun setPlayWhenReady(playWhenReady: Boolean) {
+        mainPlayer?.playWhenReady = playWhenReady
+        vrPlayer?.playWhenReady = playWhenReady
+    }
+
+    private fun recenterSensorView() {
+        if (!sensorRotationEnabled) return
+        binding.sphericalView.setUseSensorRotation(false)
+        binding.sphericalViewSecondary.setUseSensorRotation(false)
+        binding.sphericalView.post {
+            binding.sphericalView.setUseSensorRotation(true)
+            binding.sphericalViewSecondary.setUseSensorRotation(true)
+        }
+    }
+
+    private fun updateVrUi() {
+        binding.sphericalViewSecondary.visibility = if (isVrMode) View.VISIBLE else View.GONE
+        binding.controlsContainer.visibility = if (isVrMode) View.GONE else View.VISIBLE
+        binding.btnToggleVr.text = if (isVrMode) {
+            getString(R.string.exit_vr_mode)
+        } else {
+            getString(R.string.enter_vr_mode)
+        }
+    }
+
+    private fun updateZoom() {
+        binding.sphericalView.scaleX = zoomFactor
+        binding.sphericalView.scaleY = zoomFactor
+        binding.sphericalViewSecondary.scaleX = zoomFactor
+        binding.sphericalViewSecondary.scaleY = zoomFactor
+    }
+
     private fun syncPlayPauseButton() {
-        val playing = player?.playWhenReady == true
+        val playing = mainPlayer?.isPlaying == true
         binding.btnPlayPause.text = if (playing) getString(R.string.pause) else getString(R.string.play)
+    }
+
+    private inner class ZoomGestureListener : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+        override fun onScale(detector: ScaleGestureDetector): Boolean {
+            zoomFactor = (zoomFactor * detector.scaleFactor).coerceIn(minZoom, maxZoom)
+            updateZoom()
+            return true
+        }
     }
 }

--- a/app/src/main/res/layout/activity_local_spherical_player.xml
+++ b/app/src/main/res/layout/activity_local_spherical_player.xml
@@ -5,13 +5,39 @@
     android:layout_height="match_parent"
     android:background="@color/black">
 
-    <androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
-        android:id="@+id/spherical_view"
+    <LinearLayout
+        android:id="@+id/spherical_container"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
+            android:id="@+id/spherical_view"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+        <androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
+            android:id="@+id/spherical_view_secondary"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:visibility="gone" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/btn_toggle_vr"
+        style="@style/TextStyle.Main.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/enter_vr_mode"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <LinearLayout
@@ -71,6 +97,22 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:text="@string/recenter_view" />
+
+            <TextView
+                android:id="@+id/btn_zoom_out"
+                style="@style/TextStyle.Main.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="-" />
+
+            <TextView
+                android:id="@+id/btn_zoom_in"
+                style="@style/TextStyle.Main.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="+" />
 
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_connect.xml
+++ b/app/src/main/res/layout/fragment_connect.xml
@@ -58,6 +58,19 @@
         app:layout_constraintStart_toEndOf="@+id/tv_connect_ble"
         app:layout_constraintTop_toBottomOf="@+id/tv_camera_connect_status" />
 
+
+
+    <TextView
+        android:id="@+id/tv_enter_local_player"
+        style="@style/TextStyle.Main.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/button_enter_local_player"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_connect_ble" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/ll_camera_info"
         android:layout_width="match_parent"
@@ -65,7 +78,7 @@
         android:layout_marginTop="20dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tv_connect_ble"
+        app:layout_constraintTop_toBottomOf="@+id/tv_enter_local_player"
         tools:visibility="visible">
 
         <TextView
@@ -327,16 +340,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tv_camera_sd_free" />
 
-        <TextView
-            android:id="@+id/tv_enter_local_player"
-            style="@style/TextStyle.Main.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:text="@string/button_enter_local_player"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_enter_capture"
-            app:layout_constraintStart_toEndOf="@+id/tv_enter_capture"
-            app:layout_constraintTop_toTopOf="@+id/tv_enter_capture" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,8 @@
     <string name="gyro_recentered">Gyro view recentered</string>
     <string name="play">Play</string>
     <string name="pause">Pause</string>
+    <string name="enter_vr_mode">Enter VR</string>
+    <string name="exit_vr_mode">Exit VR</string>
 
     <string name="camera_storage_full_soon">Camera storage almost full</string>
     <string name="camera_battery_charging">Camera is charging, current battery: %d</string>


### PR DESCRIPTION
### Motivation
- Provide true offline 360 playback from local files without requiring a camera connection and make the local player entry always visible. 
- Ensure sensor/gyro head-tracking and zoom controls work for local equirectangular videos as they do for preview streaming. 
- Add a VR split-screen mode that loops the video, hides extra overlays while in VR, and supports head tracking for a headset-like experience.

### Description
- UI: moved the local-player entry out of the camera-info block in `fragment_connect.xml` so `tv_enter_local_player` is available even when no camera is connected. (`app/src/main/res/layout/fragment_connect.xml`).
- Local player rework: replaced the single-player implementation with a dual-player split-screen approach in `LocalSphericalPlayerActivity`: added `mainPlayer` + `vrPlayer` (`ExoPlayer`), set `repeatMode = Player.REPEAT_MODE_ALL` for automatic replay, and drive both `SphericalGLSurfaceView` instances; added `ScaleGestureDetector` for pinch zoom and `+/-` zoom buttons. (`app/src/main/java/com/arashivision/sdk/demo/ui/player/LocalSphericalPlayerActivity.kt`).
- Layouts: added a `spherical_container` holding two `SphericalGLSurfaceView` instances and a VR toggle button, plus zoom controls in `activity_local_spherical_player.xml`. Controls are hidden automatically when VR is enabled. (`app/src/main/res/layout/activity_local_spherical_player.xml`).
- Strings: added `enter_vr_mode` and `exit_vr_mode` to `strings.xml` to label the VR toggle. (`app/src/main/res/values/strings.xml`).
- Behavior notes: sensor-based head-tracking uses `setUseSensorRotation(...)` on both spherical views (so gyro affects local playback similarly to preview), VR mode shows the second view and hides overlays, and video playback is looped by the players to auto-restart when finished.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, but the wrapper was initially not executable (`Permission denied`).
- After making the wrapper executable, `./gradlew :app:compileDebugKotlin` failed due to a missing Gradle wrapper runtime (`Could not find or load main class org.gradle.wrapper.GradleWrapperMain`), so no successful automated build/test run was performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df749c8654833199d15911cca64447)