### PR TITLE
Add detection sidecar support, equirectangular projection utilities, and unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
 
     implementation(files("libs/glide_transformations.jar"))
 
+    testImplementation("junit:junit:4.13.2")
+
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/app/src/main/java/com/arashivision/sdk/demo/ui/player/LocalSphericalPlayerActivity.kt
+++ b/app/src/main/java/com/arashivision/sdk/demo/ui/player/LocalSphericalPlayerActivity.kt
@@ -4,10 +4,13 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.view.Surface
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -18,7 +21,12 @@ import com.arashivision.sdk.demo.base.BaseActivity
 import com.arashivision.sdk.demo.base.BaseEvent
 import com.arashivision.sdk.demo.databinding.ActivityLocalSphericalPlayerBinding
 import com.arashivision.sdk.demo.ui.capture.GyroOrientationController
+import com.arashivision.sdk.demo.ui.player.detection.VideoDetectionSidecarParser
+import com.arashivision.sdk.demo.ui.player.detection.VideoDetectionTimeline
 import com.elvishew.xlog.XLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @UnstableApi
 @OptIn(UnstableApi::class)
@@ -32,15 +40,29 @@ class LocalSphericalPlayerActivity :
     private lateinit var gyroController: GyroOrientationController
     private lateinit var vrManager: LocalVrManager
 
+    private val uiHandler = Handler(Looper.getMainLooper())
+    private val detectionParser = VideoDetectionSidecarParser()
+    private val detectionUpdateRunnable = object : Runnable {
+        override fun run() {
+            updateCurrentDetections()
+            uiHandler.postDelayed(this, DETECTION_UPDATE_INTERVAL_MS)
+        }
+    }
+
     private val pickVideoLauncher =
         registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
             uri ?: return@registerForActivityResult
-            kotlin.runCatching {
-                contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            }
+            persistReadPermission(uri)
             viewModel.onVideoSelected(uri)
             binding.tvSelectedVideo.text = uri.toString()
             startPlayback(uri)
+        }
+
+    private val pickJsonLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+            uri ?: return@registerForActivityResult
+            persistReadPermission(uri)
+            loadDetectionJson(uri)
         }
 
     @RequiresApi(Build.VERSION_CODES.R)
@@ -71,6 +93,7 @@ class LocalSphericalPlayerActivity :
     override fun initListener() {
         super.initListener()
         binding.btnPickVideo.setOnClickListener { pickVideoLauncher.launch(arrayOf("video/*")) }
+        binding.btnPickJson.setOnClickListener { pickJsonLauncher.launch(JSON_MIME_TYPES) }
 
         binding.btnPlayPause.setOnClickListener {
             val newState = !(player?.isPlaying ?: false)
@@ -120,6 +143,8 @@ class LocalSphericalPlayerActivity :
         vrManager.onResume()
         player?.playWhenReady = true
         syncPlayPauseButton()
+        uiHandler.removeCallbacks(detectionUpdateRunnable)
+        uiHandler.post(detectionUpdateRunnable)
     }
 
     @androidx.annotation.OptIn(UnstableApi::class)
@@ -127,11 +152,13 @@ class LocalSphericalPlayerActivity :
         vrManager.onPause()
         gyroController.stop()
         binding.sphericalView.onPause()
+        uiHandler.removeCallbacks(detectionUpdateRunnable)
         player?.playWhenReady = false
         super.onPause()
     }
 
     override fun onStop() {
+        uiHandler.removeCallbacks(detectionUpdateRunnable)
         player?.release()
         player = null
         super.onStop()
@@ -148,6 +175,7 @@ class LocalSphericalPlayerActivity :
     private fun showPlaybackSettings() {
         val actions = mutableListOf(
             getString(R.string.pick_local_video),
+            getString(R.string.add_detection_json),
             if (player?.isPlaying == true) getString(R.string.pause) else getString(R.string.play),
             if (viewModel.sensorRotationEnabled) getString(R.string.disable_gyro_control) else getString(R.string.enable_gyro_control),
             getString(R.string.recenter_view)
@@ -161,6 +189,7 @@ class LocalSphericalPlayerActivity :
             .setItems(actions.toTypedArray()) { _, which ->
                 when (actions[which]) {
                     getString(R.string.pick_local_video) -> pickVideoLauncher.launch(arrayOf("video/*"))
+                    getString(R.string.add_detection_json) -> pickJsonLauncher.launch(JSON_MIME_TYPES)
                     getString(R.string.pause), getString(R.string.play) -> {
                         val newState = !(player?.isPlaying ?: false)
                         player?.playWhenReady = newState
@@ -181,6 +210,34 @@ class LocalSphericalPlayerActivity :
             .show()
     }
 
+    private fun loadDetectionJson(uri: Uri) {
+        lifecycleScope.launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) {
+                    val json = contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+                        ?: error("Unable to open JSON file")
+                    VideoDetectionTimeline(detectionParser.parse(json))
+                }
+            }
+
+            result.onSuccess { timeline ->
+                viewModel.onJsonSelected(uri, timeline)
+                binding.tvSelectedJson.text = uri.toString()
+                toast(getString(R.string.detection_json_loaded, timeline.frameCount))
+                updateCurrentDetections()
+            }.onFailure { error ->
+                logger.e("Detection JSON load failed: ${error.message}")
+                toast(getString(R.string.detection_json_load_failed, error.message ?: "unknown"), true)
+            }
+        }
+    }
+
+    private fun persistReadPermission(uri: Uri) {
+        kotlin.runCatching {
+            contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+
     private fun startPlayback(uri: Uri) {
         val exo = player ?: return
         exo.setMediaItem(MediaItem.fromUri(uri))
@@ -192,6 +249,27 @@ class LocalSphericalPlayerActivity :
     private fun syncPlayPauseButton() {
         val playing = player?.isPlaying == true
         binding.btnPlayPause.text = if (playing) getString(R.string.pause) else getString(R.string.play)
+    }
+
+    private fun updateCurrentDetections() {
+        val positionMs = player?.currentPosition ?: 0L
+        val frame = viewModel.currentDetectionFrame(positionMs)
+
+        binding.tvDetectionDebug.text = if (frame == null) {
+            getString(R.string.no_detection_json_selected)
+        } else {
+            val detections = frame.objects
+            val trackIds = detections.joinToString { objectDetection ->
+                "#${objectDetection.trackId}"
+            }.ifEmpty { "—" }
+            getString(
+                R.string.current_detection_frame,
+                frame.frameIdx,
+                frame.timeSec,
+                detections.size,
+                trackIds
+            )
+        }
     }
 
     private fun tryApplyOrientation(yawDeg: Float, pitchDeg: Float) {
@@ -217,5 +295,10 @@ class LocalSphericalPlayerActivity :
         } catch (e: Exception) {
             logger.e("tryApplyOrientation failed: ${e.message}")
         }
+    }
+
+    companion object {
+        private val JSON_MIME_TYPES = arrayOf("application/json", "text/json", "text/plain", "application/octet-stream", "*/*")
+        private const val DETECTION_UPDATE_INTERVAL_MS = 200L
     }
 }

--- a/app/src/main/java/com/arashivision/sdk/demo/ui/player/LocalSphericalPlayerViewModel.kt
+++ b/app/src/main/java/com/arashivision/sdk/demo/ui/player/LocalSphericalPlayerViewModel.kt
@@ -2,11 +2,19 @@ package com.arashivision.sdk.demo.ui.player
 
 import android.net.Uri
 import com.arashivision.sdk.demo.base.BaseViewModel
+import com.arashivision.sdk.demo.ui.player.detection.VideoDetectionFrame
+import com.arashivision.sdk.demo.ui.player.detection.VideoDetectionTimeline
+import com.arashivision.sdk.demo.ui.player.detection.VideoDetectedObject
 
 class LocalSphericalPlayerViewModel : BaseViewModel() {
 
     var currentVideoUri: Uri? = null
         private set
+
+    var currentJsonUri: Uri? = null
+        private set
+
+    private var detectionTimeline: VideoDetectionTimeline? = null
 
     var sensorRotationEnabled: Boolean = true
         private set
@@ -14,6 +22,19 @@ class LocalSphericalPlayerViewModel : BaseViewModel() {
     fun onVideoSelected(uri: Uri) {
         currentVideoUri = uri
     }
+
+    fun onJsonSelected(uri: Uri, timeline: VideoDetectionTimeline) {
+        currentJsonUri = uri
+        detectionTimeline = timeline
+    }
+
+    fun currentDetectionFrame(positionMs: Long): VideoDetectionFrame? =
+        detectionTimeline?.frameAt(positionMs)
+
+    fun currentDetections(positionMs: Long): List<VideoDetectedObject> =
+        detectionTimeline?.detectionsAt(positionMs).orEmpty()
+
+    fun loadedDetectionFrameCount(): Int = detectionTimeline?.frameCount ?: 0
 
     fun toggleSensorRotation(): Boolean {
         sensorRotationEnabled = !sensorRotationEnabled

--- a/app/src/main/java/com/arashivision/sdk/demo/ui/player/detection/VideoDetectionModels.kt
+++ b/app/src/main/java/com/arashivision/sdk/demo/ui/player/detection/VideoDetectionModels.kt
@@ -1,0 +1,39 @@
+package com.arashivision.sdk.demo.ui.player.detection
+
+/**
+ * Parsed sidecar JSON for one panoramic video.
+ *
+ * The coordinate fields intentionally keep the source equirectangular-space values from the
+ * JSON file. Mapping these coordinates to the visible viewport is the next layer and can be
+ * added without changing the offline player.
+ */
+data class VideoDetectionSidecar(
+    val frames: List<VideoDetectionFrame>
+) {
+    val frameCount: Int = frames.size
+}
+
+data class VideoDetectionFrame(
+    val frameIdx: Int,
+    val timeSec: Double,
+    val objects: List<VideoDetectedObject>
+)
+
+data class VideoDetectedObject(
+    val trackId: Int,
+    val bboxXyxy: BboxXyxy,
+    val centerXy: Point2d,
+    val centerNorm: Point2d
+)
+
+data class BboxXyxy(
+    val left: Double,
+    val top: Double,
+    val right: Double,
+    val bottom: Double
+)
+
+data class Point2d(
+    val x: Double,
+    val y: Double
+)

--- a/app/src/main/java/com/arashivision/sdk/demo/ui/player/detection/VideoDetectionSidecarParser.kt
+++ b/app/src/main/java/com/arashivision/sdk/demo/ui/player/detection/VideoDetectionSidecarParser.kt
@@ -1,0 +1,91 @@
+package com.arashivision.sdk.demo.ui.player.detection
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.json.JSONException
+
+/** Parses detection sidecar JSON files produced for offline panoramic videos. */
+class VideoDetectionSidecarParser {
+
+    fun parse(json: String): VideoDetectionSidecar {
+        val trimmed = json.trim()
+        require(trimmed.isNotEmpty()) { "Detection JSON is empty" }
+
+        val framesArray = when (trimmed.first()) {
+            '[' -> JSONArray(trimmed)
+            '{' -> parseObjectRootOrObjectSequence(trimmed)
+            else -> error("Detection JSON must start with '[' or '{'")
+        }
+
+        val frames = buildList {
+            for (index in 0 until framesArray.length()) {
+                add(parseFrame(framesArray.getJSONObject(index)))
+            }
+        }.sortedWith(compareBy<VideoDetectionFrame> { it.timeSec }.thenBy { it.frameIdx })
+
+        return VideoDetectionSidecar(frames)
+    }
+
+    private fun parseObjectRootOrObjectSequence(json: String): JSONArray {
+        return try {
+            val root = JSONObject(json)
+            when {
+                root.has("frame_idx") -> JSONArray().put(root)
+                else -> findFramesArray(root)
+            }
+        } catch (exception: JSONException) {
+            // Some exported examples are shared as a comma-separated list of frame objects with
+            // the enclosing '[' and ']' omitted. Accept that shape as a convenience for sidecars.
+            JSONArray("[${json.trim().trimEnd(',')}]")
+        }
+    }
+
+    private fun findFramesArray(root: JSONObject): JSONArray {
+        val supportedKeys = listOf("frames", "detections", "data")
+        val key = supportedKeys.firstOrNull { root.optJSONArray(it) != null }
+        return key?.let(root::getJSONArray)
+            ?: error("Detection JSON object must contain one of: ${supportedKeys.joinToString()}")
+    }
+
+    private fun parseFrame(frameJson: JSONObject): VideoDetectionFrame {
+        val objectsJson = frameJson.optJSONArray("objects") ?: JSONArray()
+        val objects = buildList {
+            for (index in 0 until objectsJson.length()) {
+                add(parseObject(objectsJson.getJSONObject(index)))
+            }
+        }
+
+        return VideoDetectionFrame(
+            frameIdx = frameJson.getInt("frame_idx"),
+            timeSec = frameJson.getDouble("time_sec"),
+            objects = objects
+        )
+    }
+
+    private fun parseObject(objectJson: JSONObject): VideoDetectedObject {
+        return VideoDetectedObject(
+            trackId = objectJson.getInt("track_id"),
+            bboxXyxy = objectJson.getJSONArray("bbox_xyxy").toBboxXyxy(),
+            centerXy = objectJson.getJSONArray("center_xy").toPoint2d(),
+            centerNorm = objectJson.getJSONArray("center_norm").toPoint2d()
+        )
+    }
+
+    private fun JSONArray.toBboxXyxy(): BboxXyxy {
+        require(length() == 4) { "bbox_xyxy must contain four numbers" }
+        return BboxXyxy(
+            left = getDouble(0),
+            top = getDouble(1),
+            right = getDouble(2),
+            bottom = getDouble(3)
+        )
+    }
+
+    private fun JSONArray.toPoint2d(): Point2d {
+        require(length() == 2) { "point array must contain two numbers" }
+        return Point2d(
+            x = getDouble(0),
+            y = getDouble(1)
+        )
+    }
+}

--- a/app/src/main/java/com/arashivision/sdk/demo/ui/player/detection/VideoDetectionTimeline.kt
+++ b/app/src/main/java/com/arashivision/sdk/demo/ui/player/detection/VideoDetectionTimeline.kt
@@ -1,0 +1,42 @@
+package com.arashivision.sdk.demo.ui.player.detection
+
+import kotlin.math.abs
+
+/**
+ * Time-indexed access layer for detection sidecar frames.
+ *
+ * The offline player can call [frameAt] or [detectionsAt] with ExoPlayer.currentPosition to get
+ * metadata for the current playback time without coupling playback code to JSON parsing details.
+ */
+class VideoDetectionTimeline(
+    sidecar: VideoDetectionSidecar
+) {
+    private val frames: List<VideoDetectionFrame> = sidecar.frames
+
+    val frameCount: Int = frames.size
+
+    fun frameAt(positionMs: Long): VideoDetectionFrame? {
+        if (frames.isEmpty()) return null
+
+        val positionSec = positionMs / 1000.0
+        val insertionPoint = frames.binarySearchBy(positionSec) { it.timeSec }.let { result ->
+            if (result >= 0) result else -result - 1
+        }
+
+        val previous = frames.getOrNull(insertionPoint - 1)
+        val next = frames.getOrNull(insertionPoint)
+
+        return when {
+            previous == null -> next
+            next == null -> previous
+            abs(positionSec - previous.timeSec) <= abs(next.timeSec - positionSec) -> previous
+            else -> next
+        }
+    }
+
+    fun detectionsAt(positionMs: Long): List<VideoDetectedObject> =
+        frameAt(positionMs)?.objects.orEmpty()
+
+    fun frameByIndex(frameIdx: Int): VideoDetectionFrame? =
+        frames.firstOrNull { it.frameIdx == frameIdx }
+}

--- a/app/src/main/java/com/arashivision/sdk/demo/ui/player/panorama/EquirectangularProjection.kt
+++ b/app/src/main/java/com/arashivision/sdk/demo/ui/player/panorama/EquirectangularProjection.kt
@@ -1,0 +1,159 @@
+package com.arashivision.sdk.demo.ui.player.panorama
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Equirectangular panorama projection utilities.
+ *
+ * Coordinate system fixed for the offline panoramic player:
+ * - Source pixels use image coordinates: origin is the top-left corner, +x goes right, +y goes down.
+ * - Pixel coordinates are continuous edge-based coordinates in [0, width] x [0, height]. Therefore
+ *   (width / 2, height / 2) is the optical center of the equirectangular frame.
+ * - Normalized coordinates are x / width and y / height in [0, 1].
+ * - yaw = 0 at the horizontal center, yaw = -PI at the left edge, yaw = +PI at the right edge.
+ * - pitch = 0 at the vertical center, pitch = +PI/2 at the top edge, pitch = -PI/2 at the bottom edge.
+ * - 3D vectors use a right-handed world where +X is forward, +Y is right, and +Z is up.
+ *
+ * With this convention, positive yaw turns the gaze to the right, and positive pitch looks up.
+ */
+object EquirectangularProjection {
+
+    fun fromPixel(x: Double, y: Double, width: Int, height: Int): PanoramaDirection {
+        require(width > 0) { "width must be positive" }
+        require(height > 0) { "height must be positive" }
+        require(x in 0.0..width.toDouble()) { "x must be in [0, width]" }
+        require(y in 0.0..height.toDouble()) { "y must be in [0, height]" }
+
+        return fromNormalized(x / width.toDouble(), y / height.toDouble())
+    }
+
+    fun fromNormalized(x: Double, y: Double): PanoramaDirection {
+        require(x in 0.0..1.0) { "normalized x must be in [0, 1]" }
+        require(y in 0.0..1.0) { "normalized y must be in [0, 1]" }
+
+        val yawRad = (x - 0.5) * FULL_TURN_RAD
+        val pitchRad = (0.5 - y) * PI
+        return fromYawPitch(yawRad, pitchRad)
+    }
+
+    fun fromYawPitch(yawRad: Double, pitchRad: Double): PanoramaDirection {
+        require(yawRad.isFinite()) { "yawRad must be finite" }
+        require(pitchRad.isFinite()) { "pitchRad must be finite" }
+        require(pitchRad in -HALF_TURN_RAD..HALF_TURN_RAD) { "pitchRad must be in [-PI/2, PI/2]" }
+
+        val unitVector = UnitVector3.fromYawPitch(yawRad, pitchRad)
+        return PanoramaDirection(
+            yawRad = yawRad,
+            pitchRad = pitchRad,
+            unitVector = unitVector,
+            orientation = UnitQuaternion.fromYawPitch(yawRad, pitchRad)
+        )
+    }
+
+    private const val FULL_TURN_RAD = 6.283185307179586
+    private const val HALF_TURN_RAD = 1.5707963267948966
+}
+
+data class PanoramaDirection(
+    val yawRad: Double,
+    val pitchRad: Double,
+    val unitVector: UnitVector3,
+    /**
+     * Quaternion-compatible direction representation in the same +X forward, +Y right, +Z up
+     * coordinate system. Applying this quaternion to the forward vector (1, 0, 0) yields
+     * [unitVector]. Components are stored as Android/common math friendly x, y, z, w.
+     */
+    val orientation: UnitQuaternion
+) {
+    val yawDeg: Double = Math.toDegrees(yawRad)
+    val pitchDeg: Double = Math.toDegrees(pitchRad)
+}
+
+data class UnitVector3(
+    val x: Double,
+    val y: Double,
+    val z: Double
+) {
+    init {
+        require(x.isFinite() && y.isFinite() && z.isFinite()) { "vector components must be finite" }
+    }
+
+    companion object {
+        fun fromYawPitch(yawRad: Double, pitchRad: Double): UnitVector3 {
+            val cosPitch = cos(pitchRad)
+            return UnitVector3(
+                x = cosPitch * cos(yawRad),
+                y = cosPitch * sin(yawRad),
+                z = sin(pitchRad)
+            ).normalized()
+        }
+    }
+
+    fun normalized(): UnitVector3 {
+        val length = sqrt(x * x + y * y + z * z)
+        require(length > 0.0) { "cannot normalize a zero-length vector" }
+        return UnitVector3(x / length, y / length, z / length)
+    }
+}
+
+data class UnitQuaternion(
+    val x: Double,
+    val y: Double,
+    val z: Double,
+    val w: Double
+) {
+    init {
+        require(x.isFinite() && y.isFinite() && z.isFinite() && w.isFinite()) {
+            "quaternion components must be finite"
+        }
+    }
+
+    companion object {
+        val IDENTITY = UnitQuaternion(x = 0.0, y = 0.0, z = 0.0, w = 1.0)
+
+        /**
+         * Builds orientation as yaw around +Z followed by pitch around local -Y.
+         * This maps the forward vector (+X) to the same direction as [UnitVector3.fromYawPitch].
+         */
+        fun fromYawPitch(yawRad: Double, pitchRad: Double): UnitQuaternion {
+            val yaw = fromAxisAngle(axisX = 0.0, axisY = 0.0, axisZ = 1.0, angleRad = yawRad)
+            val pitch = fromAxisAngle(axisX = 0.0, axisY = -1.0, axisZ = 0.0, angleRad = pitchRad)
+            return (yaw * pitch).normalized()
+        }
+
+        private fun fromAxisAngle(axisX: Double, axisY: Double, axisZ: Double, angleRad: Double): UnitQuaternion {
+            val halfAngle = angleRad / 2.0
+            val sinHalf = sin(halfAngle)
+            return UnitQuaternion(
+                x = axisX * sinHalf,
+                y = axisY * sinHalf,
+                z = axisZ * sinHalf,
+                w = cos(halfAngle)
+            ).normalized()
+        }
+    }
+
+    operator fun times(other: UnitQuaternion): UnitQuaternion = UnitQuaternion(
+        w = w * other.w - x * other.x - y * other.y - z * other.z,
+        x = w * other.x + x * other.w + y * other.z - z * other.y,
+        y = w * other.y - x * other.z + y * other.w + z * other.x,
+        z = w * other.z + x * other.y - y * other.x + z * other.w
+    )
+
+    fun rotate(vector: UnitVector3): UnitVector3 {
+        val vectorQuaternion = UnitQuaternion(vector.x, vector.y, vector.z, 0.0)
+        val rotated = this * vectorQuaternion * conjugate()
+        return UnitVector3(rotated.x, rotated.y, rotated.z).normalized()
+    }
+
+    fun conjugate(): UnitQuaternion = UnitQuaternion(-x, -y, -z, w)
+
+    fun normalized(): UnitQuaternion {
+        val length = sqrt(x * x + y * y + z * z + w * w)
+        require(length > 0.0) { "cannot normalize a zero-length quaternion" }
+        return UnitQuaternion(x / length, y / length, z / length, w / length)
+    }
+}

--- a/app/src/main/res/layout/activity_local_spherical_player.xml
+++ b/app/src/main/res/layout/activity_local_spherical_player.xml
@@ -48,6 +48,23 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <TextView
+        android:id="@+id/tv_selected_json"
+        style="@style/TextStyle.Main.White"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:background="#66000000"
+        android:ellipsize="middle"
+        android:maxLines="1"
+        android:padding="8dp"
+        android:text="@string/no_detection_json_selected"
+        app:layout_constraintEnd_toStartOf="@+id/btn_pick_json"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_selected_video" />
+
     <ImageView
         android:id="@+id/btn_pick_video"
         android:layout_width="32dp"
@@ -58,6 +75,34 @@
         android:src="@drawable/ic_capture_setting"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/btn_pick_json"
+        style="@style/TextStyle.Main.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="center"
+        android:minWidth="72dp"
+        android:text="@string/add_detection_json_short"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_pick_video" />
+
+    <TextView
+        android:id="@+id/tv_detection_debug"
+        style="@style/TextStyle.Main.White"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:background="#66000000"
+        android:padding="8dp"
+        android:text="@string/no_detection_json_selected"
+        app:layout_constraintBottom_toTopOf="@+id/btn_play_pause"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
         android:id="@+id/btn_play_pause"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,12 @@
     <string name="pause">Pause</string>
     <string name="enter_vr_mode">Enter VR</string>
     <string name="exit_vr_mode">Exit VR</string>
+    <string name="add_detection_json">добавить json</string>
+    <string name="add_detection_json_short">JSON</string>
+    <string name="no_detection_json_selected">No detection JSON selected</string>
+    <string name="detection_json_loaded">Detection JSON loaded: %1$d frames</string>
+    <string name="detection_json_load_failed">Detection JSON load failed: %1$s</string>
+    <string name="current_detection_frame">Frame %1$d at %2$.3f s: %3$d objects (%4$s)</string>
 
     <string name="camera_storage_full_soon">Camera storage almost full</string>
     <string name="camera_battery_charging">Camera is charging, current battery: %d</string>

--- a/app/src/test/java/com/arashivision/sdk/demo/ui/player/panorama/EquirectangularProjectionTest.kt
+++ b/app/src/test/java/com/arashivision/sdk/demo/ui/player/panorama/EquirectangularProjectionTest.kt
@@ -1,0 +1,98 @@
+package com.arashivision.sdk.demo.ui.player.panorama
+
+import kotlin.math.PI
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EquirectangularProjectionTest {
+
+    @Test
+    fun centerMapsToZeroYawPitchForwardVectorAndIdentityQuaternion() {
+        val direction = EquirectangularProjection.fromPixel(x = WIDTH / 2.0, y = HEIGHT / 2.0, WIDTH, HEIGHT)
+
+        assertEquals(0.0, direction.yawRad, EPSILON)
+        assertEquals(0.0, direction.pitchRad, EPSILON)
+        assertVectorEquals(UnitVector3(1.0, 0.0, 0.0), direction.unitVector)
+        assertQuaternionEquals(UnitQuaternion.IDENTITY, direction.orientation)
+    }
+
+    @Test
+    fun horizontalEdgesMapToMinusAndPlusHalfTurnYaw() {
+        val left = EquirectangularProjection.fromPixel(x = 0.0, y = HEIGHT / 2.0, WIDTH, HEIGHT)
+        val right = EquirectangularProjection.fromPixel(x = WIDTH.toDouble(), y = HEIGHT / 2.0, WIDTH, HEIGHT)
+
+        assertEquals(-PI, left.yawRad, EPSILON)
+        assertEquals(PI, right.yawRad, EPSILON)
+        assertEquals(0.0, left.pitchRad, EPSILON)
+        assertEquals(0.0, right.pitchRad, EPSILON)
+        assertVectorEquals(UnitVector3(-1.0, 0.0, 0.0), left.unitVector)
+        assertVectorEquals(UnitVector3(-1.0, 0.0, 0.0), right.unitVector)
+    }
+
+    @Test
+    fun verticalEdgesMapToUpAndDownPitch() {
+        val top = EquirectangularProjection.fromPixel(x = WIDTH / 2.0, y = 0.0, WIDTH, HEIGHT)
+        val bottom = EquirectangularProjection.fromPixel(x = WIDTH / 2.0, y = HEIGHT.toDouble(), WIDTH, HEIGHT)
+
+        assertEquals(0.0, top.yawRad, EPSILON)
+        assertEquals(PI / 2.0, top.pitchRad, EPSILON)
+        assertVectorEquals(UnitVector3(0.0, 0.0, 1.0), top.unitVector)
+
+        assertEquals(0.0, bottom.yawRad, EPSILON)
+        assertEquals(-PI / 2.0, bottom.pitchRad, EPSILON)
+        assertVectorEquals(UnitVector3(0.0, 0.0, -1.0), bottom.unitVector)
+    }
+
+    @Test
+    fun cornersKeepYawAndPitchWhileVectorsPointToPoles() {
+        val topLeft = EquirectangularProjection.fromPixel(x = 0.0, y = 0.0, WIDTH, HEIGHT)
+        val topRight = EquirectangularProjection.fromPixel(x = WIDTH.toDouble(), y = 0.0, WIDTH, HEIGHT)
+        val bottomLeft = EquirectangularProjection.fromPixel(x = 0.0, y = HEIGHT.toDouble(), WIDTH, HEIGHT)
+        val bottomRight = EquirectangularProjection.fromPixel(x = WIDTH.toDouble(), y = HEIGHT.toDouble(), WIDTH, HEIGHT)
+
+        assertEquals(-PI, topLeft.yawRad, EPSILON)
+        assertEquals(PI, topRight.yawRad, EPSILON)
+        assertEquals(-PI, bottomLeft.yawRad, EPSILON)
+        assertEquals(PI, bottomRight.yawRad, EPSILON)
+
+        assertEquals(PI / 2.0, topLeft.pitchRad, EPSILON)
+        assertEquals(PI / 2.0, topRight.pitchRad, EPSILON)
+        assertEquals(-PI / 2.0, bottomLeft.pitchRad, EPSILON)
+        assertEquals(-PI / 2.0, bottomRight.pitchRad, EPSILON)
+
+        assertVectorEquals(UnitVector3(0.0, 0.0, 1.0), topLeft.unitVector)
+        assertVectorEquals(UnitVector3(0.0, 0.0, 1.0), topRight.unitVector)
+        assertVectorEquals(UnitVector3(0.0, 0.0, -1.0), bottomLeft.unitVector)
+        assertVectorEquals(UnitVector3(0.0, 0.0, -1.0), bottomRight.unitVector)
+    }
+
+    @Test
+    fun quaternionRotatesForwardVectorToComputedUnitVector() {
+        val direction = EquirectangularProjection.fromNormalized(x = 0.75, y = 0.25)
+        val rotatedForward = direction.orientation.rotate(FORWARD)
+
+        assertEquals(90.0, direction.yawDeg, EPSILON)
+        assertEquals(45.0, direction.pitchDeg, EPSILON)
+        assertVectorEquals(direction.unitVector, rotatedForward)
+    }
+
+    private fun assertVectorEquals(expected: UnitVector3, actual: UnitVector3) {
+        assertEquals(expected.x, actual.x, EPSILON)
+        assertEquals(expected.y, actual.y, EPSILON)
+        assertEquals(expected.z, actual.z, EPSILON)
+    }
+
+    private fun assertQuaternionEquals(expected: UnitQuaternion, actual: UnitQuaternion) {
+        assertEquals(expected.x, actual.x, EPSILON)
+        assertEquals(expected.y, actual.y, EPSILON)
+        assertEquals(expected.z, actual.z, EPSILON)
+        assertEquals(expected.w, actual.w, EPSILON)
+    }
+
+    private companion object {
+        const val WIDTH = 1280
+        const val HEIGHT = 640
+        const val EPSILON = 1e-9
+        val FORWARD = UnitVector3(1.0, 0.0, 0.0)
+    }
+}


### PR DESCRIPTION
### Motivation
- Enable loading and inspecting offline object-detection sidecar JSONs alongside local panoramic videos in the local spherical player. 
- Provide a time-indexed access layer for detections so the player can query metadata for the current playback time without coupling UI to parsing logic. 
- Add a deterministic equirectangular projection and orientation math utility to support mapping detection coordinates to directions and to allow unit testing of projection math.

### Description
- Add data models for parsed detection files in `VideoDetectionModels.kt` and a robust parser `VideoDetectionSidecarParser.kt` that accepts several JSON shapes. 
- Add `VideoDetectionTimeline.kt` to provide `frameAt`/`detectionsAt` lookup by playback time and expose frame counts. 
- Add `EquirectangularProjection.kt` with `PanoramaDirection`, unit vector and quaternion math utilities and safe validation. 
- Extend the player UI in `LocalSphericalPlayerActivity.kt` to support picking a detection JSON (`pickJsonLauncher`), persist read permissions, load and parse JSON on a background dispatcher, show loaded JSON info in the UI, and periodically update a detection debug TextView via a handler runnable. 
- Update `LocalSphericalPlayerViewModel.kt` to store the selected JSON and timeline and expose helpers `currentDetectionFrame`, `currentDetections`, and `loadedDetectionFrameCount`. 
- Add layout and string resources to display selected JSON and detection debug info. 
- Add unit tests `EquirectangularProjectionTest.kt` validating projection, vectors and quaternion behavior. 
- Add `junit` test dependency to `app/build.gradle.kts` to enable unit tests.

### Testing
- Ran unit tests with `./gradlew test` including `EquirectangularProjectionTest`, and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f5677fe08331af9613819943f755)